### PR TITLE
DuneClient as Composition of Query and Execution APIs

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,9 +2,10 @@ import { DuneError, ResultsResponse, ExecutionState, QueryParameter } from "../t
 import { ageInHours, sleep } from "../utils";
 import log from "loglevel";
 import { logPrefix } from "../utils";
-import { ExecutionClient } from "./execution";
+import { ExecutionAPI } from "./execution";
 import { POLL_FREQUENCY_SECONDS, THREE_MONTHS_IN_HOURS } from "../constants";
-import { ExecutionParams, ExecutionPerformance } from "../types/requestPayload";
+import { ExecutionParams } from "../types/requestPayload";
+import { QueryAPI } from "./query";
 
 const TERMINAL_STATES = [
   ExecutionState.CANCELLED,
@@ -12,7 +13,15 @@ const TERMINAL_STATES = [
   ExecutionState.FAILED,
 ];
 
-export class ExtendedClient extends ExecutionClient {
+export class DuneClient {
+  exec: ExecutionAPI;
+  query: QueryAPI;
+
+  constructor(apiKey: string) {
+    this.exec = new ExecutionAPI(apiKey);
+    this.query = new QueryAPI(apiKey);
+  }
+
   async runQuery(
     queryID: number,
     params?: ExecutionParams,
@@ -24,18 +33,18 @@ export class ExtendedClient extends ExecutionClient {
         params,
       )}`,
     );
-    const { execution_id: jobID } = await this.executeQuery(queryID, params);
-    let { state } = await this.getExecutionStatus(jobID);
+    const { execution_id: jobID } = await this.exec.executeQuery(queryID, params);
+    let { state } = await this.exec.getExecutionStatus(jobID);
     while (!TERMINAL_STATES.includes(state)) {
       log.info(
         logPrefix,
         `waiting for query execution ${jobID} to complete: current state ${state}`,
       );
       await sleep(pingFrequency);
-      state = (await this.getExecutionStatus(jobID)).state;
+      state = (await this.exec.getExecutionStatus(jobID)).state;
     }
     if (state === ExecutionState.COMPLETED) {
-      return this.getExecutionResults(jobID);
+      return this.exec.getExecutionResults(jobID);
     } else {
       const message = `refresh (execution ${jobID}) yields incomplete terminal state ${state}`;
       // TODO - log the error in constructor
@@ -43,22 +52,27 @@ export class ExtendedClient extends ExecutionClient {
       throw new DuneError(message);
     }
   }
-
+  /**
+   * Goes a bit beyond the internal call which returns that last execution results.
+   * Here contains additional logic to refresh the results if they are too old.
+   * @param queryId - query to get results of.
+   * @param parameters - parameters for which they were called.
+   * @param maxAgeHours - oldest acceptable results (if expired results are refreshed)
+   * @returns Latest execution results for the given parameters.
+   */
   async getLatestResult(
     queryId: number,
     parameters?: QueryParameter[],
     maxAgeHours: number = THREE_MONTHS_IN_HOURS,
   ): Promise<ResultsResponse> {
-    let results = await this._get<ResultsResponse>(`query/${queryId}/results`, {
-      query_parameters: parameters ? parameters : [],
-    });
+    let results = await this.exec.getLastExecutionResults(queryId, parameters);
     const lastRun: Date = results.execution_ended_at!;
     if (lastRun !== undefined && ageInHours(lastRun) > maxAgeHours) {
       log.info(
         logPrefix,
         `results (from ${lastRun}) older than ${maxAgeHours} hours, re-running query.`,
       );
-      results = await this.runQuery(queryId, {query_parameters: parameters});
+      results = await this.runQuery(queryId, { query_parameters: parameters });
     }
     return results;
   }
@@ -71,6 +85,6 @@ export class ExtendedClient extends ExecutionClient {
     parameters?: QueryParameter[],
     pingFrequency: number = 1,
   ): Promise<ResultsResponse> {
-    return this.runQuery(queryID, {query_parameters: parameters}, pingFrequency);
+    return this.runQuery(queryID, { query_parameters: parameters }, pingFrequency);
   }
 }

--- a/src/api/execution.ts
+++ b/src/api/execution.ts
@@ -10,7 +10,7 @@ import { Router } from "./router";
 import { ExecutionParams, ExecutionPerformance } from "../types/requestPayload";
 
 // This class implements all the routes defined in the Dune API Docs: https://dune.com/docs/api/
-export class ExecutionClient extends Router {
+export class ExecutionAPI extends Router {
   async executeQuery(
     queryID: number,
     params?: ExecutionParams,
@@ -52,6 +52,14 @@ export class ExecutionClient extends Router {
     return response as ResultsResponse;
   }
 
+  async getLastExecutionResults(
+    queryId: number,
+    parameters?: QueryParameter[],
+  ): Promise<ResultsResponse> {
+    return await this._get<ResultsResponse>(`query/${queryId}/results`, {
+      query_parameters: parameters ? parameters : [],
+    });
+  }
   // TODO - add getExecutionResultsCSV
 
   /**
@@ -61,7 +69,7 @@ export class ExecutionClient extends Router {
     queryID: number,
     parameters?: QueryParameter[],
   ): Promise<ExecutionResponse> {
-    return this.executeQuery(queryID, {query_parameters: parameters});
+    return this.executeQuery(queryID, { query_parameters: parameters });
   }
 
   /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
+export * from "./client";
 export * from "./execution";
-export * from "./extensions";
 export * from "./query";
 export * from "./router";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
-export { ExtendedClient as DuneClient } from "./api/extensions";
-export * from "./api";
+export { DuneClient, QueryAPI, ExecutionAPI } from "./api";
 export * from "./types";

--- a/tests/e2e/client.spec.ts
+++ b/tests/e2e/client.spec.ts
@@ -1,118 +1,17 @@
 import { expect } from "chai";
-import {
-  DuneClient,
-  QueryParameter,
-  ExecutionState,
-  DuneError,
-  QueryAPI,
-} from "../../src/";
+import { DuneClient, QueryParameter } from "../../src/";
 import log from "loglevel";
-import { ExecutionPerformance } from "../../src/types/requestPayload";
-
-const { DUNE_API_KEY } = process.env;
-const apiKey: string = DUNE_API_KEY ? DUNE_API_KEY : "No API Key";
+import { apiKey } from "./util";
 
 log.setLevel("silent", true);
 
-const expectAsyncThrow = async (promise: Promise<any>, message?: string | object) => {
-  try {
-    await promise;
-    // Make sure to fail if promise does resolve!
-    expect(false).to.be.equal(true);
-  } catch (error) {
-    if (message) {
-      expect(error.message).to.be.deep.equal(message);
-      expect(error).instanceOf(DuneError);
-    } else {
-      expect(error).instanceOf(DuneError);
-    }
-  }
-};
-
-describe("DuneClient: native routes", () => {
-  // This doesn't work if run too many times at once:
-  // https://discord.com/channels/757637422384283659/1019910980634939433/1026840715701010473
-  it("returns expected results on sequence execute-cancel-get_status", async () => {
-    const client = new DuneClient(apiKey);
-    // Long running query ID.
-    const queryID = 1229120;
-    // Execute and check state
-    const execution = await client.executeQuery(queryID);
-    expect(execution.state).to.be.oneOf([
-      ExecutionState.PENDING,
-      ExecutionState.EXECUTING,
-    ]);
-
-    // Cancel execution and verify it was canceled.
-    const canceled = await client.cancelExecution(execution.execution_id);
-    expect(canceled).to.be.true;
-
-    // Get execution status
-    const status = await client.getExecutionStatus(execution.execution_id);
-    const expectedStatus = {
-      state: ExecutionState.CANCELLED,
-      execution_id: execution.execution_id,
-      query_id: queryID,
-    };
-    const strippedStatus = {
-      state: status.state,
-      execution_id: status.execution_id,
-      query_id: status.query_id,
-    };
-    expect(expectedStatus).to.be.deep.equal(strippedStatus);
-  });
-
-  it("successfully executes with query parameters", async () => {
-    const client = new DuneClient(apiKey);
-    const queryID = 1215383;
-    const parameters = [
-      QueryParameter.text("TextField", "Plain Text"),
-      QueryParameter.number("NumberField", 3.1415926535),
-      QueryParameter.date("DateField", "2022-05-04 00:00:00"),
-      QueryParameter.enum("ListField", "Option 1"),
-    ];
-    // Execute and check state
-    const execution = await client.executeQuery(queryID, {
-      query_parameters: parameters,
-    });
-    expect(execution.execution_id).is.not.null;
-  });
-
-  it("execute with Large tier performance", async () => {
-    const client = new DuneClient(apiKey);
-    const execution = await client.executeQuery(1215383, {
-      performance: ExecutionPerformance.Large,
-    });
-    expect(execution.execution_id).is.not.null;
-  });
-
-  it("returns expected results on cancelled query exection", async () => {
-    const client = new DuneClient(apiKey);
-    // Execute and check state
-    const cancelledExecutionId = "01GEHEC1W8P1V5ENF66R2WY54V";
-    const result = await client.getExecutionResults(cancelledExecutionId);
-    expect(result).to.deep.equal({
-      execution_id: cancelledExecutionId,
-      query_id: 1229120,
-      state: "QUERY_STATE_CANCELLED",
-      // TODO - this is a new field - not present in our type interfaces.
-      is_execution_finished: true,
-      submitted_at: "2022-10-04T12:08:47.753527Z",
-      expires_at: "2024-10-03T12:08:48.790332Z",
-      execution_started_at: "2022-10-04T12:08:47.756608Z",
-      execution_ended_at: "2022-10-04T12:08:48.790331Z",
-      cancelled_at: "2022-10-04T12:08:48.790331Z",
-    });
-  });
-});
-
-describe("DuneClient Extensions: refresh", () => {
+describe("DuneClient Extensions", () => {
   it("execute runQuery", async () => {
     const client = new DuneClient(apiKey);
     // https://dune.com/queries/1215383
-    const results = await client.runQuery(1215383, [
-      QueryParameter.text("TextField", "Plain Text"),
-    ]);
+    const results = await client.runQuery(1215383, {
+      query_parameters: [QueryParameter.text("TextField", "Plain Text")],
+    });
     expect(results.result?.rows).to.be.deep.equal([
       {
         date_field: "2022-05-04 00:00:00.000",
@@ -130,90 +29,5 @@ describe("DuneClient Extensions: refresh", () => {
       QueryParameter.text("TextField", "Plain Text"),
     ]);
     expect(results.result?.rows.length).to.be.greaterThan(0);
-  });
-});
-
-describe("Premium: CRUD Operations", () => {
-  it("create, get & update", async () => {
-    const client = new QueryAPI(apiKey);
-    let newQuery = await client.createQuery(
-      "Name",
-      "select 1",
-      [QueryParameter.text("What", "name")],
-      true,
-    );
-    let recoveredQuery = await client.getQuery(newQuery.query_id);
-    expect(newQuery.query_id).to.be.equal(recoveredQuery.query_id);
-    let updatedQueryId = await client.updateQuery(
-      newQuery.query_id,
-      "New Name",
-      "select 10;",
-    );
-    expect(updatedQueryId).to.be.equal(recoveredQuery.query_id);
-  });
-});
-
-describe("DuneClient: Errors", () => {
-  // TODO these errors can't be reached because post method is private
-  // {"error":"unknown parameters (undefined)"}
-  // {"error":"Invalid request body payload"}
-
-  it("returns invalid API key", async () => {
-    const client = new DuneClient("Bad Key");
-    await expectAsyncThrow(client.executeQuery(1), "invalid API Key");
-  });
-  it("returns Invalid request path (queryId too large)", async () => {
-    const client = new DuneClient(apiKey);
-    await expectAsyncThrow(
-      client.executeQuery(99999999999999999999999999),
-      "Invalid request path",
-    );
-  });
-  it("returns query not found error", async () => {
-    const client = new DuneClient(apiKey);
-    await expectAsyncThrow(client.executeQuery(999999999), "Query not found");
-    await expectAsyncThrow(client.executeQuery(0), "Query not found");
-  });
-  it("returns invalid job id", async () => {
-    const client = new DuneClient(apiKey);
-    await expectAsyncThrow(client.executeQuery(999999999), "Query not found");
-
-    const invalidJobID = "Wonky Job ID";
-    const expectedErrorMessage = `The requested execution ID (ID: ${invalidJobID}) is invalid.`;
-    await expectAsyncThrow(client.getExecutionStatus(invalidJobID), expectedErrorMessage);
-    await expectAsyncThrow(
-      client.getExecutionResults(invalidJobID),
-      expectedErrorMessage,
-    );
-    await expectAsyncThrow(client.cancelExecution(invalidJobID), expectedErrorMessage);
-  });
-  it("fails execute with unknown query parameter", async () => {
-    const client = new DuneClient(apiKey);
-    const queryID = 1215383;
-    const invalidParameterName = "Invalid Parameter Name";
-    await expectAsyncThrow(
-      client.executeQuery(queryID, {
-        query_parameters: [QueryParameter.text(invalidParameterName, "")],
-      }),
-      `unknown parameters (${invalidParameterName})`,
-    );
-  });
-  it("does not allow to execute private queries for other accounts.", async () => {
-    const client = new DuneClient(apiKey);
-    await expectAsyncThrow(client.executeQuery(1348384), "Query not found");
-  });
-  it("fails with unhandled FAILED_TYPE_UNSPECIFIED when query won't compile", async () => {
-    const client = new DuneClient(apiKey);
-    // Execute and check state
-    // V1 query: 1348966
-    await expectAsyncThrow(
-      client.getExecutionResults("01GEHG4AY1Z9JBR3BYB20E7RGH"),
-      "FAILED_TYPE_EXECUTION_FAILED",
-    );
-    // V2 -query: :1349019
-    await expectAsyncThrow(
-      client.getExecutionResults("01GEHGXHQ25XWMVFJ4G2HZ5MGS"),
-      "FAILED_TYPE_EXECUTION_FAILED",
-    );
   });
 });

--- a/tests/e2e/executionAPI.spec.ts
+++ b/tests/e2e/executionAPI.spec.ts
@@ -1,0 +1,149 @@
+import { expect } from "chai";
+import { QueryParameter, ExecutionState, ExecutionAPI } from "../../src/";
+import log from "loglevel";
+import { ExecutionPerformance } from "../../src/types/requestPayload";
+import { apiKey, expectAsyncThrow } from "./util";
+
+log.setLevel("silent", true);
+
+describe("ExecutionAPI: native routes", () => {
+  // This doesn't work if run too many times at once:
+  // https://discord.com/channels/757637422384283659/1019910980634939433/1026840715701010473
+  it("returns expected results on sequence execute-cancel-get_status", async () => {
+    const client = new ExecutionAPI(apiKey);
+    // Long running query ID.
+    const queryID = 1229120;
+    // Execute and check state
+    const execution = await client.executeQuery(queryID);
+    expect(execution.state).to.be.oneOf([
+      ExecutionState.PENDING,
+      ExecutionState.EXECUTING,
+    ]);
+
+    // Cancel execution and verify it was canceled.
+    const canceled = await client.cancelExecution(execution.execution_id);
+    expect(canceled).to.be.true;
+
+    // Get execution status
+    const status = await client.getExecutionStatus(execution.execution_id);
+    const expectedStatus = {
+      state: ExecutionState.CANCELLED,
+      execution_id: execution.execution_id,
+      query_id: queryID,
+    };
+    const strippedStatus = {
+      state: status.state,
+      execution_id: status.execution_id,
+      query_id: status.query_id,
+    };
+    expect(expectedStatus).to.be.deep.equal(strippedStatus);
+  });
+
+  it("successfully executes with query parameters", async () => {
+    const client = new ExecutionAPI(apiKey);
+    const queryID = 1215383;
+    const parameters = [
+      QueryParameter.text("TextField", "Plain Text"),
+      QueryParameter.number("NumberField", 3.1415926535),
+      QueryParameter.date("DateField", "2022-05-04 00:00:00"),
+      QueryParameter.enum("ListField", "Option 1"),
+    ];
+    // Execute and check state
+    const execution = await client.executeQuery(queryID, {
+      query_parameters: parameters,
+    });
+    expect(execution.execution_id).is.not.null;
+  });
+
+  it("execute with Large tier performance", async () => {
+    const client = new ExecutionAPI(apiKey);
+    const execution = await client.executeQuery(1215383, {
+      performance: ExecutionPerformance.Large,
+    });
+    expect(execution.execution_id).is.not.null;
+  });
+
+  it("returns expected results on cancelled query exection", async () => {
+    const client = new ExecutionAPI(apiKey);
+    // Execute and check state
+    const cancelledExecutionId = "01GEHEC1W8P1V5ENF66R2WY54V";
+    const result = await client.getExecutionResults(cancelledExecutionId);
+    expect(result).to.deep.equal({
+      execution_id: cancelledExecutionId,
+      query_id: 1229120,
+      state: "QUERY_STATE_CANCELLED",
+      // TODO - this is a new field - not present in our type interfaces.
+      is_execution_finished: true,
+      submitted_at: "2022-10-04T12:08:47.753527Z",
+      expires_at: "2024-10-03T12:08:48.790332Z",
+      execution_started_at: "2022-10-04T12:08:47.756608Z",
+      execution_ended_at: "2022-10-04T12:08:48.790331Z",
+      cancelled_at: "2022-10-04T12:08:48.790331Z",
+    });
+  });
+});
+
+describe("ExecutionAPI: Errors", () => {
+  // TODO these errors can't be reached because post method is private
+  // {"error":"unknown parameters (undefined)"}
+  // {"error":"Invalid request body payload"}
+
+  it("returns invalid API key", async () => {
+    const client = new ExecutionAPI("Bad Key");
+    await expectAsyncThrow(client.executeQuery(1), "invalid API Key");
+  });
+  it("returns Invalid request path (queryId too large)", async () => {
+    const client = new ExecutionAPI(apiKey);
+    await expectAsyncThrow(
+      client.executeQuery(99999999999999999999999999),
+      "Invalid request path",
+    );
+  });
+  it("returns query not found error", async () => {
+    const client = new ExecutionAPI(apiKey);
+    await expectAsyncThrow(client.executeQuery(999999999), "Query not found");
+    await expectAsyncThrow(client.executeQuery(0), "Query not found");
+  });
+  it("returns invalid job id", async () => {
+    const client = new ExecutionAPI(apiKey);
+    await expectAsyncThrow(client.executeQuery(999999999), "Query not found");
+
+    const invalidJobID = "Wonky Job ID";
+    const expectedErrorMessage = `The requested execution ID (ID: ${invalidJobID}) is invalid.`;
+    await expectAsyncThrow(client.getExecutionStatus(invalidJobID), expectedErrorMessage);
+    await expectAsyncThrow(
+      client.getExecutionResults(invalidJobID),
+      expectedErrorMessage,
+    );
+    await expectAsyncThrow(client.cancelExecution(invalidJobID), expectedErrorMessage);
+  });
+  it("fails execute with unknown query parameter", async () => {
+    const client = new ExecutionAPI(apiKey);
+    const queryID = 1215383;
+    const invalidParameterName = "Invalid Parameter Name";
+    await expectAsyncThrow(
+      client.executeQuery(queryID, {
+        query_parameters: [QueryParameter.text(invalidParameterName, "")],
+      }),
+      `unknown parameters (${invalidParameterName})`,
+    );
+  });
+  it("does not allow to execute private queries for other accounts.", async () => {
+    const client = new ExecutionAPI(apiKey);
+    await expectAsyncThrow(client.executeQuery(1348384), "Query not found");
+  });
+  it("fails with unhandled FAILED_TYPE_UNSPECIFIED when query won't compile", async () => {
+    const client = new ExecutionAPI(apiKey);
+    // Execute and check state
+    // V1 query: 1348966
+    await expectAsyncThrow(
+      client.getExecutionResults("01GEHG4AY1Z9JBR3BYB20E7RGH"),
+      "FAILED_TYPE_EXECUTION_FAILED",
+    );
+    // V2 -query: :1349019
+    await expectAsyncThrow(
+      client.getExecutionResults("01GEHGXHQ25XWMVFJ4G2HZ5MGS"),
+      "FAILED_TYPE_EXECUTION_FAILED",
+    );
+  });
+});

--- a/tests/e2e/queryAPI.spec.ts
+++ b/tests/e2e/queryAPI.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+import { QueryParameter, DuneError, QueryAPI } from "../../src/";
+import { apiKey } from "./util";
+
+describe("QueryAPI: Premium - CRUD Operations", () => {
+  it("create, get & update", async () => {
+    const client = new QueryAPI(apiKey);
+    let newQuery = await client.createQuery(
+      "Name",
+      "select 1",
+      [QueryParameter.text("What", "name")],
+      true,
+    );
+    let recoveredQuery = await client.getQuery(newQuery.query_id);
+    expect(newQuery.query_id).to.be.equal(recoveredQuery.query_id);
+    let updatedQueryId = await client.updateQuery(
+      newQuery.query_id,
+      "New Name",
+      "select 10;",
+    );
+    expect(updatedQueryId).to.be.equal(recoveredQuery.query_id);
+  });
+});

--- a/tests/e2e/util.ts
+++ b/tests/e2e/util.ts
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+import { DuneError } from "../../src";
+
+const { DUNE_API_KEY } = process.env;
+export const apiKey: string = DUNE_API_KEY ? DUNE_API_KEY : "No API Key";
+
+export const expectAsyncThrow = async (
+  promise: Promise<any>,
+  message?: string | object,
+) => {
+  try {
+    await promise;
+    // Make sure to fail if promise does resolve!
+    expect(false).to.be.equal(true);
+  } catch (error) {
+    if (message) {
+      expect(error.message).to.be.deep.equal(message);
+      expect(error).instanceOf(DuneError);
+    } else {
+      expect(error).instanceOf(DuneError);
+    }
+  }
+};


### PR DESCRIPTION
1. Construct intended main entry point class DuneClient as the composition of QueryAPI and ExecutionAPI. 
2. NOTE that this is a breaking change to the interface now users will do things like:

```
dune.query.update
dune.query.create
dune.query.make_private (I still need to implement this).

dune.exec.query
dune.exec.getResults
dune.exec.getStatus
```
3. Tests are split up and rearranged.
