### PR TITLE
Run SQL

### DIFF
--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -71,7 +71,7 @@ export class QueryAPI extends Router {
    * @returns {boolean} indicating success of request.
    */
   public async archiveQuery(queryId: number): Promise<boolean> {
-    const response = await this._post<EditQueryResponse>(`/query/${queryId}/archive`);
+    const response = await this._post<EditQueryResponse>(`query/${queryId}/archive`);
     const query = await this.readQuery(response.query_id);
     return query.is_archived;
   }
@@ -83,7 +83,7 @@ export class QueryAPI extends Router {
    * @returns {boolean} indicating success of request.
    */
   public async unarchiveQuery(queryId: number): Promise<boolean> {
-    const response = await this._post<EditQueryResponse>(`/query/${queryId}/unarchive`);
+    const response = await this._post<EditQueryResponse>(`query/${queryId}/unarchive`);
     const query = await this.readQuery(response.query_id);
     return query.is_archived;
   }
@@ -96,7 +96,7 @@ export class QueryAPI extends Router {
    * @returns {number} ID of the query made private.
    */
   public async makePrivate(queryId: number): Promise<number> {
-    const response = await this._post<EditQueryResponse>(`/query/${queryId}/private`);
+    const response = await this._post<EditQueryResponse>(`query/${queryId}/private`);
     const query = await this.readQuery(response.query_id);
     if (!query.is_private) {
       throw new DuneError("Query was not made private!");
@@ -111,7 +111,7 @@ export class QueryAPI extends Router {
    * @returns {number} ID of the query made public.
    */
   public async makePublic(queryId: number): Promise<number> {
-    const response = await this._post<EditQueryResponse>(`/query/${queryId}/unprivate`);
+    const response = await this._post<EditQueryResponse>(`query/${queryId}/unprivate`);
     const query = await this.readQuery(response.query_id);
     if (query.is_private) {
       throw new DuneError("Query is still private.");

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -60,7 +60,7 @@ export class Router {
       }
     } catch (error) {
       log.error(logPrefix, `caught unhandled response error ${JSON.stringify(error)}`);
-      throw error;
+      throw new DuneError(`Response ${error}`);
     }
     return result;
   }

--- a/tests/e2e/client.spec.ts
+++ b/tests/e2e/client.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { DuneClient, QueryParameter } from "../../src/";
 import log from "loglevel";
-import { BASIC_KEY } from "./util";
+import { BASIC_KEY, PLUS_KEY } from "./util";
 import * as fs from "fs/promises";
 
 log.setLevel(log.levels.DEBUG, true);
@@ -88,5 +88,14 @@ describe("DuneClient Extensions", () => {
     expect(fileContents).to.deep.equal("number\n3\n4\n5\n6\n7\n8\n");
     // Remove the CSV file after the comparison
     await fs.unlink("./out.csv");
+  });
+
+  it("runSQL", async () => {
+    const premiumClient = new DuneClient(PLUS_KEY);
+    const results = await premiumClient.runSql("select 1", [], true, true);
+    const queryID = results.query_id;
+    expect(results.result?.rows).to.be.deep.equal([{ _col0: 1 }]);
+    const query = await premiumClient.query.readQuery(queryID);
+    expect(query.is_archived).to.be.equal(true);
   });
 });

--- a/tests/e2e/queryAPI.spec.ts
+++ b/tests/e2e/queryAPI.spec.ts
@@ -28,6 +28,25 @@ describe("QueryAPI: Premium - CRUD Operations", () => {
     });
     expect(updatedQueryId).to.be.equal(recoveredQuery.query_id);
   });
+
+  it.only("unarchive, make public, make private, rearchive", async () => {
+    const queryId = 3530410;
+    let query = await plusClient.readQuery(queryId);
+    expect(query.is_archived).to.be.equal(true);
+    expect(query.is_private).to.be.equal(true);
+
+    await plusClient.unarchiveQuery(queryId);
+    await plusClient.makePublic(queryId);
+    query = await plusClient.readQuery(queryId);
+    expect(query.is_archived).to.be.equal(false);
+    expect(query.is_private).to.be.equal(false);
+
+    await plusClient.archiveQuery(queryId);
+    await plusClient.makePrivate(queryId);
+    query = await plusClient.readQuery(queryId);
+    expect(query.is_archived).to.be.equal(true);
+    expect(query.is_private).to.be.equal(true);
+  });
 });
 
 describe("QueryAPI: Errors", () => {


### PR DESCRIPTION
Implements runSQL (create, execute, get results)

Also found a bug in archive and make private endpoints that were fixed and tested here.

Mirroring python code here:

https://github.com/duneanalytics/dune-client/blob/78e5f4a1bd77d2b07394b68d6feef6360b7cf223/dune_client/api/extensions.py#L357-L381