### PR TITLE
Fix Deprecated Build Notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
   "name": "@duneanalytics/client-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Ben Smith <bh2smith@gmail.com>",
   "description": "Node Client for Dune Analytics' officially supported API.",
   "repository": "git@github.com:bh2smith/ts-dune-client.git",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "ts-mocha 'tests/**/*.spec.ts' -r dotenv/config --timeout 10000",


### PR DESCRIPTION
There was some problem importing the recently published package. Had to import from "@duneanalytics/client-sdk/dist/src" for TS to find it. Weird stuff. I hope this fixes it (tested locally via npm link).